### PR TITLE
Add static AdaptableBlotter.init fn which returns the api

### DIFF
--- a/packages/adaptableblotter/App_Scripts/agGrid/AdaptableBlotter.ts
+++ b/packages/adaptableblotter/App_Scripts/agGrid/AdaptableBlotter.ts
@@ -261,6 +261,12 @@ export class AdaptableBlotter implements IAdaptableBlotter {
   private emit = (eventName: string, data?: any): Promise<any> =>
     this.emitter.emit(eventName, data);
 
+  public static init(blotterOptions: AdaptableBlotterOptions): BlotterApi {
+    const ab = new AdaptableBlotter(blotterOptions);
+
+    return ab.api;
+  }
+
   constructor(
     blotterOptions: AdaptableBlotterOptions,
     renderGrid: boolean = true,
@@ -1117,7 +1123,10 @@ export class AdaptableBlotter implements IAdaptableBlotter {
     if (ArrayExtensions.IsEmpty(percentBars)) {
       return false;
     }
-    return ArrayExtensions.ContainsItem(percentBars.map(pb => pb.ColumnId), columnId);
+    return ArrayExtensions.ContainsItem(
+      percentBars.map(pb => pb.ColumnId),
+      columnId
+    );
   }
 
   public getDisplayValue(id: any, columnId: string): string {
@@ -2962,7 +2971,7 @@ export class AdaptableBlotter implements IAdaptableBlotter {
     // every theme should define a custom css variable: --ab-theme-loaded: <themeName> defined on the document element.
     if (abThemeLoaded !== themeName) {
       LoggingHelper.LogWarning(`Theme "${themeName}" doesn't seem to be loaded! Make sure you import the css file for the "${themeName}" theme!
-        
+
 If it's a default theme, try
 
 import "adaptableblotter/themes/${themeName}.css"`);
@@ -3069,6 +3078,9 @@ interface AdaptableBlotterWizardOptions {
   };
 }
 
+export const init = (blotterOptions: AdaptableBlotterOptions): BlotterApi =>
+  AdaptableBlotter.init(blotterOptions);
+  
 export class AdaptableBlotterWizard implements IAdaptableBlotterWizard {
   private init: WizardInitFn;
 

--- a/packages/adaptableblotter/App_Scripts/agGrid/index.ts
+++ b/packages/adaptableblotter/App_Scripts/agGrid/index.ts
@@ -1,5 +1,10 @@
-import { AdaptableBlotter, AdaptableBlotterWizard as ABWizard } from './AdaptableBlotter';
+import {
+  AdaptableBlotter,
+  init as initFn,
+  AdaptableBlotterWizard as ABWizard,
+} from './AdaptableBlotter';
 
 export default AdaptableBlotter;
 
 export const AdaptableBlotterWizard = ABWizard;
+export const init = initFn;

--- a/packages/adaptableblotter/examples/pages/agGrid/basicdemo/agGrid.tsx
+++ b/packages/adaptableblotter/examples/pages/agGrid/basicdemo/agGrid.tsx
@@ -8,15 +8,16 @@ import '../../../../App_Scripts/themes/dark.scss';
 import './index.css';
 
 import { GridOptions } from 'ag-grid-community';
-import AdaptableBlotter from '../../../../App_Scripts/agGrid';
+import AdaptableBlotter, { init } from '../../../../App_Scripts/agGrid';
 import {
   AdaptableBlotterOptions,
   PredefinedConfig,
   IAdaptableBlotter,
+  BlotterApi,
 } from '../../../../App_Scripts/types';
 import { ExamplesHelper } from '../../ExamplesHelper';
 
-var adaptableblotter: IAdaptableBlotter;
+var api: BlotterApi;
 
 function InitAdaptableBlotter() {
   const examplesHelper = new ExamplesHelper();
@@ -41,7 +42,7 @@ function InitAdaptableBlotter() {
     autoSizeColumnsInLayout: true,
   };
 
-  adaptableblotter = new AdaptableBlotter(adaptableBlotterOptions);
+  api = init(adaptableBlotterOptions);
 }
 
 let demoConfig: PredefinedConfig = {


### PR DESCRIPTION
Also add init named export.

So people can use the blotter in 3 ways:
 - like before - `import AB from '@adaptabletools/adatableblotter/agGrid'`, `new AB(blotterOptions)`
 - `import AB from '@adaptabletools/adatableblotter/agGrid'`, and then `const api = AB.init(blotterOptions)`
 - `import {init} from '@adaptabletools/adatableblotter/agGrid'`, and then `const api = init(blotterOptions)`

@JonnyAdaptableTools do you think we should keep both 2 and 3? or just provide one or the other?